### PR TITLE
fix the quantity error in robot_uids

### DIFF
--- a/robofactory/tasks/lift_barrier.py
+++ b/robofactory/tasks/lift_barrier.py
@@ -35,7 +35,7 @@ class LiftBarrierEnv(BaseEnv):
     cube_half_size = 0.02
 
     def __init__(
-        self, *args, robot_uids=("panda", "panda", "panda"), robot_init_qpos_noise=0.02, **kwargs
+        self, *args, robot_uids=("panda", "panda",), robot_init_qpos_noise=0.02, **kwargs
     ):
         if 'config' in kwargs:
             with open(kwargs['config'], 'r', encoding='utf-8') as f:

--- a/robofactory/tasks/long_pipeline_delivery.py
+++ b/robofactory/tasks/long_pipeline_delivery.py
@@ -32,7 +32,7 @@ class LongPipelineDeliveryEnv(BaseEnv):
     cube_half_size = 0.02
 
     def __init__(
-        self, *args, robot_uids=("panda", "panda", "panda"), robot_init_qpos_noise=0.02, **kwargs
+        self, *args, robot_uids=("panda", "panda", "panda", "panda"), robot_init_qpos_noise=0.02, **kwargs
     ):
         if 'config' in kwargs:
             with open(kwargs['config'], 'r', encoding='utf-8') as f:

--- a/robofactory/tasks/pass_shoe.py
+++ b/robofactory/tasks/pass_shoe.py
@@ -34,7 +34,7 @@ class PassShoeEnv(BaseEnv):
     cube_half_size = 0.02
 
     def __init__(
-        self, *args, robot_uids=("panda", "panda", "panda"), robot_init_qpos_noise=0.02, **kwargs
+        self, *args, robot_uids=("panda", "panda"), robot_init_qpos_noise=0.02, **kwargs
     ):
         if 'config' in kwargs:
             with open(kwargs['config'], 'r', encoding='utf-8') as f:

--- a/robofactory/tasks/pick_meat.py
+++ b/robofactory/tasks/pick_meat.py
@@ -30,7 +30,7 @@ class PickMeatEnv(BaseEnv):
     cube_half_size = 0.02
 
     def __init__(
-        self, *args, robot_uids=("panda", "panda", "panda"), robot_init_qpos_noise=0.02, **kwargs
+        self, *args, robot_uids=("panda"), robot_init_qpos_noise=0.02, **kwargs
     ):
         if 'config' in kwargs:
             with open(kwargs['config'], 'r', encoding='utf-8') as f:

--- a/robofactory/tasks/place_food.py
+++ b/robofactory/tasks/place_food.py
@@ -35,7 +35,7 @@ class PlaceFoodEnv(BaseEnv):
     cube_half_size = 0.02
 
     def __init__(
-        self, *args, robot_uids=("panda", "panda", "panda"), robot_init_qpos_noise=0.02, **kwargs
+        self, *args, robot_uids=("panda", "panda"), robot_init_qpos_noise=0.02, **kwargs
     ):
         if 'config' in kwargs:
             with open(kwargs['config'], 'r', encoding='utf-8') as f:

--- a/robofactory/tasks/stack_cube.py
+++ b/robofactory/tasks/stack_cube.py
@@ -27,7 +27,7 @@ class StackCubeEnv(BaseEnv):
     cube_half_size = torch.tensor([0.02] * 3)
 
     def __init__(
-        self, *args, robot_uids=("panda", "panda", "panda"), robot_init_qpos_noise=0.02, **kwargs
+        self, *args, robot_uids=("panda"), robot_init_qpos_noise=0.02, **kwargs
     ):
         if 'config' in kwargs:
             with open(kwargs['config'], 'r', encoding='utf-8') as f:

--- a/robofactory/tasks/strike_cube.py
+++ b/robofactory/tasks/strike_cube.py
@@ -22,7 +22,7 @@ class StrikeCubeEnv(BaseEnv):
     SUPPORTED_ROBOTS = ["panda"]
     cube_half_size = 0.02
     def __init__(
-        self, *args, robot_uids=("panda", "panda", "panda"), robot_init_qpos_noise=0.02, **kwargs
+        self, *args, robot_uids=("panda", ), robot_init_qpos_noise=0.02, **kwargs
     ):
         if 'config' in kwargs:
             with open(kwargs['config'], 'r', encoding='utf-8') as f:

--- a/robofactory/tasks/take_photo.py
+++ b/robofactory/tasks/take_photo.py
@@ -28,7 +28,7 @@ class TakePhotoEnv(BaseEnv):
     goal_thresh = 0.025
 
     def __init__(
-        self, *args, robot_uids=("panda", "panda", "panda"), robot_init_qpos_noise=0.02, **kwargs
+        self, *args, robot_uids=("panda", "panda", "panda", "panda"), robot_init_qpos_noise=0.02, **kwargs
     ):
         if 'config' in kwargs:
             with open(kwargs['config'], 'r', encoding='utf-8') as f:

--- a/robofactory/tasks/two_robots_stack_cube.py
+++ b/robofactory/tasks/two_robots_stack_cube.py
@@ -32,7 +32,7 @@ class TwoRobotsStackCubeEnv(BaseEnv):
     goal_radius = 0.11
 
     def __init__(
-        self, *args, robot_uids=("panda", "panda", "panda"), robot_init_qpos_noise=0.02, **kwargs
+        self, *args, robot_uids=("panda", "panda"), robot_init_qpos_noise=0.02, **kwargs
     ):
         if 'config' in kwargs:
             with open(kwargs['config'], 'r', encoding='utf-8') as f:


### PR DESCRIPTION
The `robot_uids` variable is correspond to the quantity of agent. It was not found in previous commit.
```python
def __init__(
        self, *args, robot_uids=("panda", "panda", "panda"), robot_init_qpos_noise=0.02, **kwargs
    ):
        if 'config' in kwargs:
            with open(kwargs['config'], 'r', encoding='utf-8') as f:
                cfg = yaml.load(f.read(), Loader=yaml.FullLoader)
            del kwargs['config']
        else:
            if 'scene' in kwargs:
                scene = kwargs['scene']
                del kwargs['scene']
            else:
                scene = 'table'
            with open(osp.join(CONFIG_DIR, scene, 'camera_alignment.yaml'), 'r', encoding='utf-8') as f:
                cfg = yaml.load(f.read(), Loader=yaml.FullLoader)
        self.cfg = nested_yaml_map(replace_dir, cfg)
        super().__init__(*args, robot_uids=robot_uids, **kwargs)
```
I used the follow scripts to test and it did not report any error
```python
import robofactory as rf
import gymnasium as gym

tasks = ['CameraAlignment-rf', 'LiftBarrier-rf', 'LongPipelineDelivery-rf', 'PassShoe-rf',
         'PickMeat-rf', 'PlaceFood-rf', 'StackCube-rf', 'StrikeCube-rf', 'TakePhoto-rf',
         'ThreeRobotsStackCube-rf', 'TwoRobotsStackCube-rf']

for task in tasks:
    env = gym.make(id=task, sim_backend='physx_cpu')
    env.reset(seed=42)
```