### PR TITLE
Fix --vis multi-trajectory crash and macOS render backend

### DIFF
--- a/robofactory/planner/motionplanner.py
+++ b/robofactory/planner/motionplanner.py
@@ -61,7 +61,12 @@ class PandaArmMotionPlanningSolver:
         if self.vis and self.visualize_target_grasp_pose:
             self.grasp_pose_visual = []
             for id in range(self.agent_num):
-                self.grasp_pose_visual.append(build_panda_gripper_grasp_pose_visual(self.base_env.scene, "grasp_pose_visual" + str(id)))
+                # reuse the actor if a previous solver in this env already built it
+                name = "grasp_pose_visual" + str(id)
+                if name in self.base_env.scene.actors:
+                    self.grasp_pose_visual.append(self.base_env.scene.actors[name])
+                else:
+                    self.grasp_pose_visual.append(build_panda_gripper_grasp_pose_visual(self.base_env.scene, name))
                 self.grasp_pose_visual[id].set_pose(self.base_pose[id])
         
         self.elapsed_steps = 0

--- a/robofactory/planner/run.py
+++ b/robofactory/planner/run.py
@@ -1,5 +1,6 @@
 import multiprocessing as mp
 import os
+import platform
 from copy import deepcopy
 import time
 import argparse
@@ -64,6 +65,8 @@ def _main(args, proc_id: int = 0, start_seed: int = 0) -> str:
         human_render_camera_configs=dict(shader_pack=args.shader),
         viewer_camera_configs=dict(shader_pack=args.shader),
         sim_backend=args.sim_backend,
+        # macOS has no CUDA; ManiSkill's default render_backend="gpu" maps to a cuda device
+        render_backend="cpu" if platform.system() == "Darwin" else "gpu",
     )
     if env_id not in MP_SOLUTIONS:
         raise RuntimeError(f"No already written motion planning solutions for {env_id}. Available options are {list(MP_SOLUTIONS.keys())}")


### PR DESCRIPTION
## Summary

Two independent fixes:

### 1. `--vis` crashes on the second trajectory (all platforms)

Each trajectory creates a new `PandaArmMotionPlanningSolver`, which builds the `grasp_pose_visual{id}` indicator actors with fixed names in the same scene. ManiSkill asserts that actor names are unique, so any visualized run with `-n` > 1 crashes at the start of the second trajectory:

```
AssertionError: built actors in ManiSkill must have unique names and cannot be None or empty strings
```

Fix: reuse the actor if it is already present in `scene.actors` instead of rebuilding it.

Verified: `python -m robofactory.planner.run -c configs/table/lift_barrier.yaml -b cpu -n 3 --vis` now completes all 3 trajectories with `success_rate=1`.

### 2. Tasks fail to start on macOS

ManiSkill's default `render_backend="gpu"` resolves to a CUDA device, which does not exist on macOS (`RuntimeError: failed to find device "cuda"`). Pass `render_backend="cpu"` on Darwin so tasks run with SAPIEN's Metal (MoltenVK) renderer. No behavior change on Linux/Windows.

With this (plus a SAPIEN nightly macOS wheel and an mplib built from source), the full pipeline — simulation, viewer GUI, motion-planning data generation — runs on Apple Silicon.

## Test plan

- [x] `python -m robofactory.planner.run -c configs/table/lift_barrier.yaml -b cpu -n 3 --vis` on macOS (M3 Max): 3/3 trajectories, `success_rate=1`, viewer window works
- [x] Headless `-n 2 --render-mode rgb_array`: unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
